### PR TITLE
Added option to specify JRE executable file

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ launcher.authenticator.getAuth("email", "password").then(auth => {
 | `options.clientPackage`  | String | Path to the client package zip file.                                                      | False    |
 | `options.root`           | String | Path where you want the launcher to work in.  like `C:/Users/user/AppData/Roaming/.mc`    | True     |
 | `options.os`             | String | windows, osx or linux                                                                     | True     |
+| `options.javaPath`       | String | Path to the JRE executable file, will default to `java` if not entered.                   | False    |
 | `options.version.number` | String | Minecraft version that is going to be launched.                                           | True     |
 | `options.version.type`   | String | Any string. The actual Minecraft launcher uses `release` and `snapshot`.                  | True     |
 | `options.memory.max`     | String | Max amount of memory being used by Minectaft                                              | True     |

--- a/components/launcher.js
+++ b/components/launcher.js
@@ -61,7 +61,7 @@ module.exports = async function (options) {
 
     const launchArguments = args.concat(jvm, classPaths, launchOptions);
 
-    const minecraft = child.spawn(`java`, launchArguments);
+    const minecraft = child.spawn(options.javaPath ? options.javaPath : 'java', launchArguments);
     event.emit('start', null);
     minecraft.stdout.on('data', (data) => event.emit('data', data));
     minecraft.stderr.on('data', (data) => event.emit('error', data));


### PR DESCRIPTION
Hello! First of all - thank you for the clean and solid lib. You saved me a lot of time :)

I made a small adjustment that allows to specify java executable path, which can be useful when you don't want to rely on system's java installation, or even make user think about java installation, and want to provide it by your own instead. (As modern Mojang's launcher do)

(I personally used this util https://github.com/jkawamoto/node-jre for such solution)