### PR TITLE
Fix oversight in existing version JSON file test

### DIFF
--- a/components/handler.js
+++ b/components/handler.js
@@ -70,8 +70,8 @@ class Handler {
 
     getVersion() {
         return new Promise(resolve => {
-            if(fs.existsSync(path.join(this.options.directory, 'versions', this.options.version.number, `${this.options.version.number}.json`))) {
-                this.version = require(path.join(this.options.directory, 'versions', this.options.version.number, `${this.options.version.number}.json`));
+            if(fs.existsSync(path.join(this.options.directory, `${this.options.version.number}.json`))) {
+                this.version = require(path.join(this.options.directory, `${this.options.version.number}.json`));
                 resolve(this.version);
                 return;
             }


### PR DESCRIPTION
Fixes an oversight in the way getVersion() tests for preexisting version JSON files. A redundant version folder is joined to the path, leading to the check never realistically succeeding; options.directory already contains the version folder when the function is called. (https://github.com/Pierce01/MinecraftLauncher-core/blob/fafd828/components/launcher.js#L28-L32)