### PR TITLE
Fixed custom launch args builder - #39

### DIFF
--- a/components/handler.js
+++ b/components/handler.js
@@ -515,6 +515,8 @@ class Handler {
                 this.options.proxy.password
             );
 
+            if(this.options.customLaunchArgs) this.options.customLaunchArgs.forEach(customArg => args = args.concat(customArg.split(' ')))
+
             this.client.emit('debug', '[MCLC]: Set launch options');
             resolve(args);
         });


### PR DESCRIPTION
For a weird reason, the custom launch args have to be an array instead of a single string. I transformed the custom launch args builder from a simple string to an array formatter.

It works perfectly now.