### PR TITLE
Remove the hardcoded "M" in the JVM memory allocation argument.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ let opts = {
         type: "release"
     },
     memory: {
-        max: "6000",
-        min: "4000"
+        max: "6G",
+        min: "4G"
     }
 }
 

--- a/components/launcher.js
+++ b/components/launcher.js
@@ -92,8 +92,8 @@ class MCLCore extends EventEmitter {
       '-Dfml.ignorePatchDiscrepancies=true',
       '-Dfml.ignoreInvalidMinecraftCertificates=true',
       `-Djava.library.path=${nativePath}`,
-      `-Xmx${this.options.memory.max}M`,
-      `-Xms${this.options.memory.min}M`
+      `-Xmx${this.options.memory.max}`,
+      `-Xms${this.options.memory.min}`
     ]
     if (this.handler.getOS() === 'osx') {
       if (parseInt(versionFile.id.split('.')[1]) > 12) jvm.push(await this.handler.getJVM())


### PR DESCRIPTION
I think the JVM memory allocation argument should not do forced to megabytes.