### PR TITLE
Add a gameDirectory to your options

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ launcher.on('data', (e) => console.log(e));
 | `options.removePackage`  | Boolean  | Option to remove the client package zip file after its finished extracting.                | False    |
 | `options.installer`      | String   | Path to installer being executed.                                                         | False    |
 | `options.root`           | String   | Path where you want the launcher to work in.  like `C:/Users/user/AppData/Roaming/.mc`,   | True     |
+| `options.gameDirectofy`  | String   | Path where you want the game to work in.  If you don't specify it, it will be in the same place as root.| False    |
 | `options.os`             | String   | windows, osx or linux. MCLC will auto determine the OS if this field isn't provided.      | False    |
 | `options.customLaunchArgs`| Array   | Array of custom Minecraft arguments you want to add.                                 | False    |
 | `options.customArgs`     | Array    | Array of custom Java arguments you want to add.                                           | False    |

--- a/components/handler.js
+++ b/components/handler.js
@@ -497,7 +497,7 @@ class Handler {
       '${user_type}': 'mojang',
       '${version_name}': this.options.version.number,
       '${assets_index_name}': this.version.assetIndex.id,
-      '${game_directory}': this.options.root,
+      '${game_directory}': this.options.gameDirectory || this.options.root,
       '${assets_root}': assetPath,
       '${game_assets}': assetPath,
       '${version_type}': this.options.version.type

--- a/components/launcher.js
+++ b/components/launcher.js
@@ -8,6 +8,9 @@ class MCLCore extends EventEmitter {
   async launch (options) {
     this.options = options
     this.options.root = path.resolve(this.options.root)
+    if (this.options.gameDirectory) {
+      this.options.gameDirectory = path.resolve(this.options.gameDirectory)
+    }
     this.options.overrides = {
       detached: true,
       ...this.options.overrides,


### PR DESCRIPTION
Allows you to specify a working directory for the game, separate from the location where the launcher is running.
This is worthy of a "GAME DIRECTORY" section in the official launcher.