### PR TITLE
Split large MCLCore#launch into multiple methods

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -206,6 +206,12 @@ declare module "minecraft-launcher-core" {
 
   export class Client extends EventEmitter {
     launch(options: ILauncherOptions): ChildProcessWithoutNullStreams | null;
+    protected printVersion(): void;
+    protected createRootDirectory(): void;
+    protected createGameDirectory(): void;
+    protected async extractPackage(): void;
+    protected async getModifyJson(): any;
+    protected startMinecraft(launchArguments: string[]): ChildProcessWithoutNullStreams;
   }
 
   export const Authenticator: IAuthenticator;


### PR DESCRIPTION
This PR splits up the `MCLCore#launch` method into multiple smaller methods which should increase the readability.

It should not change any functionality.