### PR TITLE
fix: download to correct folder if custom is specified

### DIFF
--- a/components/handler.js
+++ b/components/handler.js
@@ -133,7 +133,7 @@ class Handler {
   }
 
   async getJar () {
-    await this.downloadAsync(this.version.downloads.client.url, this.options.directory, `${this.options.version.number}.jar`, true, 'version-jar')
+    await this.downloadAsync(this.version.downloads.client.url, this.options.directory, `${this.options.version.custom ? this.options.version.custom : this.options.version.number}.jar`, true, 'version-jar')
 
     fs.writeFileSync(path.join(this.options.directory, `${this.options.version.number}.json`), JSON.stringify(this.version, null, 4))
 

--- a/components/launcher.js
+++ b/components/launcher.js
@@ -52,7 +52,7 @@ class MCLCore extends EventEmitter {
       await this.handler.runInstaller(this.options.installer)
     }
 
-    const directory = this.options.overrides.directory || path.join(this.options.root, 'versions', this.options.version.number)
+    const directory = this.options.overrides.directory || path.join(this.options.root, 'versions', this.options.version.custom ? this.options.version.custom : this.options.version.number)
     this.options.directory = directory
 
     const versionFile = await this.handler.getVersion()


### PR DESCRIPTION
download the .json and the jar to the custom folder if it is specified

works with and without custom being set

I've made sure it works in all scenarios 
this is semver minor I guess as it fixes a bug