### PR TITLE
Added launch hooks needed by Microsoft authentication

### DIFF
--- a/components/handler.js
+++ b/components/handler.js
@@ -551,20 +551,24 @@ class Handler {
     if (args.length < minArgs) args = args.concat(this.version.minecraftArguments ? this.version.minecraftArguments.split(' ') : this.version.arguments.game)
 
     this.options.authorization = await Promise.resolve(this.options.authorization)
-
+    this.options.authorization.meta = this.options.authorization.meta ? this.options.authorization.meta : { type: 'mojang' }
     const fields = {
       '${auth_access_token}': this.options.authorization.access_token,
       '${auth_session}': this.options.authorization.access_token,
       '${auth_player_name}': this.options.authorization.name,
       '${auth_uuid}': this.options.authorization.uuid,
       '${user_properties}': this.options.authorization.user_properties,
-      '${user_type}': 'mojang',
+      '${user_type}': this.options.authorization.meta.type,
       '${version_name}': this.options.version.number,
       '${assets_index_name}': this.version.assetIndex.id,
       '${game_directory}': this.options.overrides.gameDirectory || this.options.root,
       '${assets_root}': assetPath,
       '${game_assets}': assetPath,
       '${version_type}': this.options.version.type
+    }
+
+    if (this.options.authorization.meta.demo) {
+      args.push('--demo')
     }
 
     for (let index = 0; index < args.length; index++) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -143,10 +143,7 @@ declare module "minecraft-launcher-core" {
     authorization: Promise<IUser>;
   }
 
-  interface IMeta {
-    type: "mojang" | "xbox",
-    demo?: boolean
-  }
+
 
   interface IUser {
     access_token: string;
@@ -154,7 +151,10 @@ declare module "minecraft-launcher-core" {
     uuid: string;
     name: string;
     user_properties: Partial<any>;
-    meta?: IMeta;
+    meta?: {
+      type: "mojang" | "xbox",
+      demo?: boolean
+    };
   }
 
   interface IProfile {

--- a/index.d.ts
+++ b/index.d.ts
@@ -152,7 +152,7 @@ declare module "minecraft-launcher-core" {
     name: string;
     user_properties: Partial<any>;
     meta?: {
-      type: "mojang" | "xbox",
+      type: "mojang" | "msa",
       demo?: boolean
     };
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -143,12 +143,18 @@ declare module "minecraft-launcher-core" {
     authorization: Promise<IUser>;
   }
 
+  interface IMeta {
+    type: "mojang" | "xbox",
+    demo?: boolean
+  }
+
   interface IUser {
     access_token: string;
     client_token: string;
     uuid: string;
     name: string;
     user_properties: Partial<any>;
+    meta?: IMeta;
   }
 
   interface IProfile {


### PR DESCRIPTION
Added a optional meta field to the interface IUser that that contains 2 sub-fields 

the first of two sub fields contain information about if the account is a mojang or microsoft account. The second contains information stating if a set account is a demo account (I just thought it could be useful)

I also added checks to components/handler.js to use the new field. If the field is absent, a filler value will be used that will make mclc behave as it did before this change.