### PR TITLE
Fix EMFILE: too many open files when not connected to internet

### DIFF
--- a/components/handler.js
+++ b/components/handler.js
@@ -37,7 +37,8 @@ class Handler {
   downloadAsync (url, directory, name, retry, type) {
     return new Promise(resolve => {
       fs.mkdirSync(directory, { recursive: true })
-
+      if(!navigator.onLine)
+        reject("offline")
       const _request = this.baseRequest(url)
 
       let receivedBytes = 0


### PR DESCRIPTION
Avoid this type of after too many launch try (theorically on the third launch() call):
```
EMFILE: too many open files, open 'C:\Users\quent\AppData\Roaming\altarik-launcher\logs\main.log'
    at File.writeLine (C:\Users\quent\Documents\Altarik\Launcher\node_modules\electron-log\src\transports\file\file.js:144:7)
    at transport (C:\Users\quent\Documents\Altarik\Launcher\node_modules\electron-log\src\transports\file\index.js:72:10)
    at runTransport (C:\Users\quent\Documents\Altarik\Launcher\node_modules\electron-log\src\log.js:44:5)
    at runTransports (C:\Users\quent\Documents\Altarik\Launcher\node_modules\electron-log\src\log.js:27:7)
    at log (C:\Users\quent\Documents\Altarik\Launcher\node_modules\electron-log\src\log.js:21:3)
    at MCLCore.<anonymous> (C:\Users\quent\Documents\Altarik\Launcher\src\server\minecraft.js:100:57)
    at MCLCore.emit (events.js:327:22)
    at Request.<anonymous> (C:\Users\quent\Documents\Altarik\Launcher\node_modules\minecraft-launcher-core\components\handler.js:56:21)
    at Request.emit (events.js:327:22)
    at Request.onRequestError (C:\Users\quent\Documents\Altarik\Launcher\node_modules\request\request.js:877:8)
```
When you got this type of error, it become impossible to download assets after reconnecting to internet.
    
Untested yet so I create this PR as a draft