### PR TITLE
Custom version name was not appearing on F3 screen

### DIFF
--- a/components/handler.js
+++ b/components/handler.js
@@ -568,7 +568,7 @@ class Handler {
       '${user_properties}': this.options.authorization.user_properties,
       '${user_type}': this.options.authorization.meta.type,
       '${version_name}': this.options.version.number,
-      '${assets_index_name}': this.version.assetIndex.id,
+      '${assets_index_name}': this.options.version.custom || this.options.version.number,
       '${game_directory}': this.options.overrides.gameDirectory || this.options.root,
       '${assets_root}': assetPath,
       '${game_assets}': assetPath,


### PR DESCRIPTION
When launching custom versions from vanilla launcher like Fabric, OptiFine you'll notice it'll show up as Minecraft 1.8.9 (OptFine_FOO_BARR/vanilla) at top of the debug menu. MCLC was using options.number instead of options.custom and it was causing that problem.