### PR TITLE
Cache manifest json files

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,11 @@ launcher.on('data', (e) => console.log(e));
 
 | Parameter                | Type     | Description                                                                               | Required |
 |--------------------------|----------|-------------------------------------------------------------------------------------------|----------|
-| `options.clientPackage`  | String   | Path or URL to a zip file, which will be extracted to the root directory. (Not recommended for produnction use)| False    |
+| `options.clientPackage`  | String   | Path or URL to a zip file, which will be extracted to the root directory. (Not recommended for production use)| False    |
 | `options.removePackage`  | Boolean  | Option to remove the client package zip file after its finished extracting.               | False    |
 | `options.installer`      | String   | Path to installer being executed.                                                         | False    |
 | `options.root`           | String   | Path where you want the launcher to work in.  like `C:/Users/user/AppData/Roaming/.mc`,   | True     |
+| `options.cache`           | String   | Path where launcher files will be cached in.  like `C:/Users/user/AppData/Roaming/.mc/cache`,   | False     |
 | `options.os`             | String   | windows, osx or linux. MCLC will auto determine the OS if this field isn't provided.      | False    |
 | `options.customLaunchArgs`| Array   | Array of custom Minecraft arguments you want to add.                                      | False    |
 | `options.customArgs`     | Array    | Array of custom Java arguments you want to add.                                           | False    |

--- a/components/handler.js
+++ b/components/handler.js
@@ -112,35 +112,35 @@ class Handler {
       }
 
       const manifest = `${this.options.overrides.url.meta}/mc/game/version_manifest.json`
-      const cache = this.options.cache? `${this.options.cache}/json`: `${this.options.root}/cache/json`
+      const cache = this.options.cache ? `${this.options.cache}/json` : `${this.options.root}/cache/json`
       request.get(manifest, (error, response, body) => {
-        if (error && error.code !== 'ENOTFOUND') return resolve(error);
-        if (!error) { 
-          if(!fs.existsSync(cache)) {
-            fs.mkdirSync(cache, { recursive: true });
+        if (error && error.code !== 'ENOTFOUND') return resolve(error)
+        if (!error) {
+          if (!fs.existsSync(cache)) {
+            fs.mkdirSync(cache, { recursive: true })
             this.client.emit('debug', '[MCLC]: Cache directory created.')
           }
           fs.writeFile(path.join(`${cache}/version_manifest.json`), body, (err) => {
-            if (err) return resolve(err);
+            if (err) return resolve(err)
             this.client.emit('debug', '[MCLC]: Cached version_manifest.json')
           })
         }
 
-        const parsed = JSON.parse(error?.code == 'ENOTFOUND'? fs.readFileSync(`${cache}/version_manifest.json`): body)
-        
+        const parsed = JSON.parse(error?.code === 'ENOTFOUND' ? fs.readFileSync(`${cache}/version_manifest.json`) : body)
+
         for (const desiredVersion in parsed.versions) {
           if (parsed.versions[desiredVersion].id === this.options.version.number) {
             request.get(parsed.versions[desiredVersion].url, (error, response, body) => {
-              if (error && error.code !== 'ENOTFOUND') return resolve(error) 
-              if (!error) { 
+              if (error && error.code !== 'ENOTFOUND') return resolve(error)
+              if (!error) {
                 fs.writeFile(path.join(`${cache}/${this.options.version.number}.json`), body, (err) => {
-                  if (err) return resolve(err);
+                  if (err) return resolve(err)
                   this.client.emit('debug', `[MCLC]: Cached ${this.options.version.number}.json`)
                 })
               }
 
               this.client.emit('debug', '[MCLC]: Parsed version from version manifest')
-              this.version = JSON.parse(error?.code == 'ENOTFOUND'? fs.readFileSync(`${cache}/${this.options.version.number}.json`): body)
+              this.version = JSON.parse(error?.code === 'ENOTFOUND' ? fs.readFileSync(`${cache}/${this.options.version.number}.json`) : body)
               return resolve(this.version)
             })
           }

--- a/components/handler.js
+++ b/components/handler.js
@@ -121,7 +121,7 @@ class Handler {
             this.client.emit('debug', '[MCLC]: Cache directory created.')
           }
           fs.writeFile(path.join(`${cache}/version_manifest.json`), body, (err) => {
-            if (err) resolve(err)
+            if (err) return resolve(err);
             this.client.emit('debug', '[MCLC]: Cached version_manifest.json')
           })
         }
@@ -134,7 +134,7 @@ class Handler {
               if (error && error.code !== 'ENOTFOUND') return resolve(error) 
               if (!error) { 
                 fs.writeFile(path.join(`${cache}/${this.options.version.number}.json`), body, (err) => {
-                  if (err) resolve(err)
+                  if (err) return resolve(err);
                   this.client.emit('debug', `[MCLC]: Cached ${this.options.version.number}.json`)
                 })
               }

--- a/components/handler.js
+++ b/components/handler.js
@@ -112,18 +112,35 @@ class Handler {
       }
 
       const manifest = `${this.options.overrides.url.meta}/mc/game/version_manifest.json`
+      const cache = this.options.cache? `${this.options.cache}/json`: `${this.options.root}/cache/json`
       request.get(manifest, (error, response, body) => {
-        if (error) return resolve(error)
+        if (error && error.code !== 'ENOTFOUND') return resolve(error);
+        if (!error) { 
+          if(!fs.existsSync(cache)) {
+            fs.mkdirSync(cache, { recursive: true });
+            this.client.emit('debug', '[MCLC]: Cache directory created.')
+          }
+          fs.writeFile(path.join(`${cache}/version_manifest.json`), body, (err) => {
+            if (err) console.log(err)
+            this.client.emit('debug', '[MCLC]: Cached version_manifest.json')
+          })
+        }
 
-        const parsed = JSON.parse(body)
-
+        const parsed = JSON.parse(error?.code == 'ENOTFOUND'? fs.readFileSync(`${cache}/version_manifest.json`): body)
+        
         for (const desiredVersion in parsed.versions) {
           if (parsed.versions[desiredVersion].id === this.options.version.number) {
             request.get(parsed.versions[desiredVersion].url, (error, response, body) => {
-              if (error) return resolve(error)
+              if (error && error.code !== 'ENOTFOUND') return resolve(error) 
+              if (!error) { 
+                fs.writeFile(path.join(`${cache}/${this.options.version.number}.json`), body, (err) => {
+                  if (err) console.log(err)
+                  this.client.emit('debug', `[MCLC]: Cached ${this.options.version.number}.json`)
+                })
+              }
 
               this.client.emit('debug', '[MCLC]: Parsed version from version manifest')
-              this.version = JSON.parse(body)
+              this.version = JSON.parse(error?.code == 'ENOTFOUND'? fs.readFileSync(`${cache}/${this.options.version.number}.json`): body)
               return resolve(this.version)
             })
           }

--- a/components/handler.js
+++ b/components/handler.js
@@ -121,7 +121,7 @@ class Handler {
             this.client.emit('debug', '[MCLC]: Cache directory created.')
           }
           fs.writeFile(path.join(`${cache}/version_manifest.json`), body, (err) => {
-            if (err) console.log(err)
+            if (err) resolve(err)
             this.client.emit('debug', '[MCLC]: Cached version_manifest.json')
           })
         }
@@ -134,7 +134,7 @@ class Handler {
               if (error && error.code !== 'ENOTFOUND') return resolve(error) 
               if (!error) { 
                 fs.writeFile(path.join(`${cache}/${this.options.version.number}.json`), body, (err) => {
-                  if (err) console.log(err)
+                  if (err) resolve(err)
                   this.client.emit('debug', `[MCLC]: Cached ${this.options.version.number}.json`)
                 })
               }

--- a/components/handler.js
+++ b/components/handler.js
@@ -126,7 +126,12 @@ class Handler {
           })
         }
 
-        const parsed = JSON.parse(error?.code === 'ENOTFOUND' ? fs.readFileSync(`${cache}/version_manifest.json`) : body)
+        let parsed
+        if (error && (error.code === 'ENOTFOUND')) {
+          parsed = JSON.parse(fs.readFileSync(`${cache}/version_manifest.json`))
+        } else {
+          parsed = JSON.parse(body)
+        }
 
         for (const desiredVersion in parsed.versions) {
           if (parsed.versions[desiredVersion].id === this.options.version.number) {
@@ -140,7 +145,11 @@ class Handler {
               }
 
               this.client.emit('debug', '[MCLC]: Parsed version from version manifest')
-              this.version = JSON.parse(error?.code === 'ENOTFOUND' ? fs.readFileSync(`${cache}/${this.options.version.number}.json`) : body)
+              if (error && (error.code === 'ENOTFOUND')) {
+                this.version = JSON.parse(fs.readFileSync(`${cache}/${this.options.version.number}.json`))
+              } else {
+                this.version = JSON.parse(body)
+              }
               return resolve(this.version)
             })
           }

--- a/index.d.ts
+++ b/index.d.ts
@@ -152,6 +152,10 @@ declare module "minecraft-launcher-core" {
     };
     overrides?: IOverrides;
     authorization: Promise<IUser>;
+    /**
+     * Path of json cache.
+     */
+    cache?: string;
   }
 
 


### PR DESCRIPTION
Version manifest files used to be forcibly downloaded every time the game tried to start, which meant it wasn't possible to start up the game without an internet connection. What these changes do is cache both version.json files locally whenever there is an internet connection, so that in case the user tries to start up the game while offline, the client can start up just fine.