### PR TITLE
Fix (CustomVersion): Error when the custom version value was to Fabric

### DIFF
--- a/components/launcher.js
+++ b/components/launcher.js
@@ -185,7 +185,7 @@ class MCLCore extends EventEmitter {
       modifyJson = await this.handler.getForgedWrapped()
     } else if (this.options.version.custom) {
       this.emit('debug', '[MCLC]: Detected custom in options, setting custom version file')
-      modifyJson = modifyJson || JSON.parse(fs.readFileSync(path.join(this.options.root, 'versions', this.options.version.custom, `${this.options.version.custom}.json`), { encoding: 'utf8' }))
+      modifyJson = modifyJson || JSON.parse(fs.readFileSync(path.join(this.options.root, 'versions', this.options.version.custom, `${this.options.version.number}.json`), { encoding: 'utf8' }))
     }
 
     return modifyJson


### PR DESCRIPTION
## Describe 
When running the game with the `options.version.custom` option set to `fabric`, the module downloads the correct version of the `loader` json file, under the name :
`${minecraft_version}.json`.

However, when loading the file, it tried to load the `${options.version.custom}.json` file, which caused an error and prevented the game from launching.

## How to reproduce the bug
Just set the value of the `version.custom` option to `fabric`.

For example:
```js
const { Client, Authenticator } = require('minecraft-launcher-core');
const launcher = new Client();

let opts = {
    // For production launchers, I recommend not passing 
    // the getAuth function through the authorization field and instead
    // handling authentication outside before you initialize
    // MCLC so you can handle auth based errors and validation!
    authorization: Authenticator.getAuth("username", "password"),
    root: "./minecraft",
    version: {
        number: "1.18.2",
        type: "release",
        custom: "fabric"
    },
    memory: {
        max: "6G",
        min: "4G"
    }
}

launcher.launch(opts);

launcher.on('debug', (e) => console.log(e));
launcher.on('data', (e) => console.log(e));
```

## How does this RP solve the problem?
Simply by changing the name of the file you are looking for.
We leave it with the name `${options.version.number}.json`, but instead of looking for `${options.version.custom}.json`, we look for the file `${options.version.number}.json`.
And, it works!

Resolve: #107 