### PR TITLE
Fixed custom mod loader crashes

### DIFF
--- a/components/launcher.js
+++ b/components/launcher.js
@@ -125,7 +125,7 @@ class MCLCore extends EventEmitter {
       // So mods like fabric work.
       const jar = fs.existsSync(mcPath)
         ? `${separator}${mcPath}`
-        : `${separator}${path.join(directory, `${this.options.version.number}.jar`)}`
+        : `${separator}${path.join(directory, `${this.options.overrides.minecraftJar||this.options.version.custom||this.options.version.number}.jar`)}`
       classPaths.push(`${this.options.forge ? this.options.forge + separator : ''}${classes.join(separator)}${jar}`)
       classPaths.push(file.mainClass)
 


### PR DESCRIPTION
# Issue
When using this module to launch mod loaders like fabric and forge, the argument of -cp uses Minecraft_version.jar instead of the specific format of forge or fabric like 1.18.2-forge-40.2.0.jar, making Minecraft crash.

# Fix
Use the name of the jar file if specified, or use the custom version if specified, otherwise use the version number.

---
This is my first time contributing to a GitHub project, sorry if I did anything wrong. 