### PR TITLE
Fix no artifact property when downloading a library

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ##### This project is complete for now.
 [![Build Status](https://travis-ci.com/Pierce01/MinecraftLauncher-core.svg?branch=master)](https://travis-ci.com/Pierce01/MinecraftLauncher-core)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-![version](https://img.shields.io/badge/stable_version-3.17.0-blue)
+![version](https://img.shields.io/badge/stable_version-3.17.1-blue)
 ![badge](https://img.shields.io/badge/ncurses-not_supported-purple)
 
 MCLC (Minecraft Launcher Core) is a NodeJS solution for launching modded and vanilla Minecraft without having to download and format everything yourself.

--- a/components/handler.js
+++ b/components/handler.js
@@ -509,13 +509,26 @@ class Handler {
         jarPath = path.join(directory, `${lib[0].replace(/\./g, '/')}/${lib[1]}/${lib[2]}`)
       }
 
-      if (!fs.existsSync(path.join(jarPath, name)) || !this.checkSum(library.downloads.artifact.sha1, path.join(jarPath, name))) {
+      // Fix no artifact property when downloading a library
+      if (!fs.existsSync(path.join(jarPath, name))) {
         // Simple lib support, forgot which addon needed this but here you go, Mr special.
         if (library.url) {
           const url = `${library.url}${lib[0].replace(/\./g, '/')}/${lib[1]}/${lib[2]}/${name}`
           await this.downloadAsync(url, jarPath, name, true, eventName)
         } else if (library.downloads && library.downloads.artifact) {
           await this.downloadAsync(library.downloads.artifact.url, jarPath, name, true, eventName)
+        }
+      }
+
+      if(library.downloads){
+        if(!this.checkSum(library.downloads.artifact.sha1, path.join(jarPath, name))){
+          // Simple lib support, forgot which addon needed this but here you go, Mr special.
+          if (library.url) {
+            const url = `${library.url}${lib[0].replace(/\./g, '/')}/${lib[1]}/${lib[2]}/${name}`
+            await this.downloadAsync(url, jarPath, name, true, eventName)
+          } else if (library.downloads && library.downloads.artifact) {
+            await this.downloadAsync(library.downloads.artifact.url, jarPath, name, true, eventName)
+          }
         }
       }
 

--- a/components/handler.js
+++ b/components/handler.js
@@ -509,9 +509,7 @@ class Handler {
         jarPath = path.join(directory, `${lib[0].replace(/\./g, '/')}/${lib[1]}/${lib[2]}`)
       }
 
-      // Fix no artifact property when downloading a library
-      if (!fs.existsSync(path.join(jarPath, name))) {
-        // Simple lib support, forgot which addon needed this but here you go, Mr special.
+      const downloadLibrary = async library => {
         if (library.url) {
           const url = `${library.url}${lib[0].replace(/\./g, '/')}/${lib[1]}/${lib[2]}/${name}`
           await this.downloadAsync(url, jarPath, name, true, eventName)
@@ -520,16 +518,9 @@ class Handler {
         }
       }
 
-      if(library.downloads){
-        if(!this.checkSum(library.downloads.artifact.sha1, path.join(jarPath, name))){
-          // Simple lib support, forgot which addon needed this but here you go, Mr special.
-          if (library.url) {
-            const url = `${library.url}${lib[0].replace(/\./g, '/')}/${lib[1]}/${lib[2]}/${name}`
-            await this.downloadAsync(url, jarPath, name, true, eventName)
-          } else if (library.downloads && library.downloads.artifact) {
-            await this.downloadAsync(library.downloads.artifact.url, jarPath, name, true, eventName)
-          }
-        }
+      if (!fs.existsSync(path.join(jarPath, name))) downloadLibrary(library)
+      else if (library.downloads && library.downloads.artifact) {
+        if (!this.checkSum(library.downloads.artifact.sha1, path.join(jarPath, name))) downloadLibrary(library)
       }
 
       counter++

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minecraft-launcher-core",
-  "version": "3.17.0",
+  "version": "3.17.1",
   "description": "Lightweight module that downloads and runs Minecraft using javascript / NodeJS",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
This should make it possible to launch custom clients with version.json files specifying libraries without downloading, as shown here:

```
{
  "id": "1.19.2-OptiFine_HD_U_H9",
  "inheritsFrom": "1.19.2",
  "time": "2022-11-02T20:19:20+01:00",
  "releaseTime": "2022-11-02T20:19:20+01:00",
  "type": "release",
  "libraries": [
    {
      "name": "optifine:OptiFine:1.19.2_HD_U_H9"
    },
    {
      "name": "optifine:launchwrapper-of:2.3"
    }
  ],
  "mainClass": "net.minecraft.launchwrapper.Launch",
  "arguments": {
    "game": [
      "--tweakClass",
      "optifine.OptiFineTweaker"
    ]
  }
}
```

and correct this error : `[MCLC]: Failed to start due to TypeError: Cannot read properties of undefined (reading 'artifact'), closing...`