### PR TITLE
Fixing launcher errors by assigning two jsons

### DIFF
--- a/components/handler.js
+++ b/components/handler.js
@@ -598,7 +598,7 @@ class Handler {
   }
 
   async getLaunchOptions (modification) {
-    const type = modification || this.version
+    const type = Object.assign(this.version, modification)
 
     let args = type.minecraftArguments
       ? type.minecraftArguments.split(' ')

--- a/components/handler.js
+++ b/components/handler.js
@@ -598,7 +598,7 @@ class Handler {
   }
 
   async getLaunchOptions (modification) {
-    const type = Object.assign(this.version, modification)
+    const type = Object.assign({}, this.version, modification)
 
     let args = type.minecraftArguments
       ? type.minecraftArguments.split(' ')


### PR DESCRIPTION
This fixes custom versions that don't provide all necessary arguments in their version.json, so I think it will be right if we assign two objects with the priority of custom version.json.