### PR TITLE
Better assets progress

### DIFF
--- a/components/handler.js
+++ b/components/handler.js
@@ -190,13 +190,13 @@ class Handler {
       if (!fs.existsSync(path.join(subAsset, hash)) || !await this.checkSum(hash, path.join(subAsset, hash))) {
         await this.downloadAsync(`${this.options.overrides.url.resource}/${subhash}/${hash}`, subAsset, hash,
           true, 'assets')
-        counter++
-        this.client.emit('progress', {
+      }
+      counter++
+      this.client.emit('progress', {
           type: 'assets',
           task: counter,
           total: Object.keys(index.objects).length
-        })
-      }
+      })
     }))
     counter = 0
 


### PR DESCRIPTION
I just moved counter and emit operation under the if statement. The reason for that is when I get assets progress, it was instantly finishing from 20, 30, 0 etc...
And this makes harder to check the current progress.