### PR TITLE
Only include vanilla libraries, if they aren't duplicates

### DIFF
--- a/components/handler.js
+++ b/components/handler.js
@@ -530,7 +530,7 @@ class Handler {
     }
 
     const parsed = this.version.libraries.map(lib => {
-      if (lib.downloads && lib.downloads.artifact && !this.parseRule(lib)) return lib
+      if (lib.downloads && lib.downloads.artifact && !this.parseRule(lib) && !classJson.libraries.some(l => l.name.split(':')[0] == lib.name.split(':')[0])) return lib
     })
 
     libs = libs.concat((await this.downloadToDirectory(libraryDirectory, parsed, 'classes')))

--- a/components/handler.js
+++ b/components/handler.js
@@ -529,8 +529,13 @@ class Handler {
       libs = await this.downloadToDirectory(libraryDirectory, classJson.libraries, 'classes-custom')
     }
 
-    const parsed = this.version.libraries.map(lib => {
-      if (lib.downloads && lib.downloads.artifact && !this.parseRule(lib) && !classJson.libraries.some(l => l.name.split(':')[0] == lib.name.split(':')[0])) return lib
+    const parsed = this.version.libraries.filter(lib => {
+      if (lib.downloads && lib.downloads.artifact && !this.parseRule(lib)) {
+        if (!classJson || !classJson.libraries.some(l => l.name.split(':')[1] === lib.name.split(':')[1])) {
+          return true
+        }
+      }
+      return false
     })
 
     libs = libs.concat((await this.downloadToDirectory(libraryDirectory, parsed, 'classes')))

--- a/components/handler.js
+++ b/components/handler.js
@@ -536,9 +536,6 @@ class Handler {
     libs = libs.concat((await this.downloadToDirectory(libraryDirectory, parsed, 'classes')))
     counter = 0
 
-    // Temp Quilt support
-    if (classJson) libs.sort()
-
     this.client.emit('debug', '[MCLC]: Collected class paths')
     return libs
   }


### PR DESCRIPTION
This solution isn't ideal, since it iterates over `classJson.libraries` a bunch of times, but I didn't want to change too much code and this does seem to work