### PR TITLE
Fixed checksum, log4j.xml, forge download paths

### DIFF
--- a/components/handler.js
+++ b/components/handler.js
@@ -501,7 +501,7 @@ class Handler {
 
       if (!fs.existsSync(path.join(jarPath, name))) await downloadLibrary(library)
       if (library.downloads && library.downloads.artifact) {
-        if (!this.checkSum(library.downloads.artifact.sha1, path.join(jarPath, name))) await downloadLibrary(library)
+        if (!await this.checkSum(library.downloads.artifact.sha1, path.join(jarPath, name))) await downloadLibrary(library)
       }
 
       counter++

--- a/components/handler.js
+++ b/components/handler.js
@@ -329,7 +329,7 @@ class Handler {
   async getForgedWrapped () {
     let json = null
     let installerJson = null
-    const versionPath = path.join(this.options.overrides.directory, `forge-${this.version.id}`, 'version.json')
+    const versionPath = path.join(this.options.overrides.directory || this.options.root, `forge-${this.version.id}`, 'version.json')
     // Since we're building a proper "custom" JSON that will work nativly with MCLC, the version JSON will not
     // be re-generated on the next run.
     if (fs.existsSync(versionPath)) {
@@ -460,8 +460,8 @@ class Handler {
     json.forgeWrapperVersion = this.options.overrides.fw.version
 
     // Saving file for next run!
-    if (!fs.existsSync(path.join(this.options.overrides.directory, `forge-${this.version.id}`))) {
-      fs.mkdirSync(path.join(this.options.overrides.directory, `forge-${this.version.id}`), { recursive: true })
+    if (!fs.existsSync(path.join(this.options.overrides.directory || this.options.root, `forge-${this.version.id}`))) {
+      fs.mkdirSync(path.join(this.options.overrides.directory || this.options.root, `forge-${this.version.id}`), { recursive: true })
     }
     fs.writeFileSync(versionPath, JSON.stringify(json, null, 4))
 

--- a/components/handler.js
+++ b/components/handler.js
@@ -329,7 +329,7 @@ class Handler {
   async getForgedWrapped () {
     let json = null
     let installerJson = null
-    const versionPath = path.join(this.options.root, 'forge', `${this.version.id}`, 'version.json')
+    const versionPath = path.join(this.options.overrides.directory, `forge-${this.version.id}`, 'version.json')
     // Since we're building a proper "custom" JSON that will work nativly with MCLC, the version JSON will not
     // be re-generated on the next run.
     if (fs.existsSync(versionPath)) {
@@ -460,8 +460,8 @@ class Handler {
     json.forgeWrapperVersion = this.options.overrides.fw.version
 
     // Saving file for next run!
-    if (!fs.existsSync(path.join(this.options.root, 'forge', this.version.id))) {
-      fs.mkdirSync(path.join(this.options.root, 'forge', this.version.id), { recursive: true })
+    if (!fs.existsSync(path.join(this.options.overrides.directory, `forge-${this.version.id}`))) {
+      fs.mkdirSync(path.join(this.options.overrides.directory, `forge-${this.version.id}`), { recursive: true })
     }
     fs.writeFileSync(versionPath, JSON.stringify(json, null, 4))
 

--- a/components/launcher.js
+++ b/components/launcher.js
@@ -93,12 +93,16 @@ class MCLCore extends EventEmitter {
           const configPath = path.resolve(this.options.overrides.cwd || this.options.root)
           const intVersion = parseInt(versionFile.id.split('.')[1])
           if (intVersion >= 12) {
-            await this.handler.downloadAsync('https://launcher.mojang.com/v1/objects/02937d122c86ce73319ef9975b58896fc1b491d1/log4j2_112-116.xml',
-              configPath, 'log4j2_112-116.xml', true, 'log4j')
+            if (!fs.existsSync(path.join(configPath, 'log4j2_112-116.xml'))) {
+              await this.handler.downloadAsync('https://launcher.mojang.com/v1/objects/02937d122c86ce73319ef9975b58896fc1b491d1/log4j2_112-116.xml',
+                configPath, 'log4j2_112-116.xml', true, 'log4j')
+            }
             jvm.push('-Dlog4j.configurationFile=log4j2_112-116.xml')
           } else if (intVersion >= 7) {
-            await this.handler.downloadAsync('https://launcher.mojang.com/v1/objects/dd2b723346a8dcd48e7f4d245f6bf09e98db9696/log4j2_17-111.xml',
-              configPath, 'log4j2_17-111.xml', true, 'log4j')
+            if (!fs.existsSync(path.join(configPath, 'log4j2_17-111.xml'))) {
+              await this.handler.downloadAsync('https://launcher.mojang.com/v1/objects/dd2b723346a8dcd48e7f4d245f6bf09e98db9696/log4j2_17-111.xml',
+                configPath, 'log4j2_17-111.xml', true, 'log4j')
+            }
             jvm.push('-Dlog4j.configurationFile=log4j2_17-111.xml')
           }
         }

--- a/components/launcher.js
+++ b/components/launcher.js
@@ -54,7 +54,7 @@ class MCLCore extends EventEmitter {
 
       const versionFile = await this.handler.getVersion()
       const mcPath = this.options.overrides.minecraftJar || (this.options.version.custom
-        ? path.join(this.options.root, 'versions', this.options.version.custom, `${this.options.version.custom}.jar`)
+        ? path.join(this.options.overrides.directory || path.join(this.options.root, 'versions', this.options.version.custom), `${this.options.version.custom}.jar`)
         : path.join(directory, `${this.options.version.number}.jar`))
       this.options.mcPath = mcPath
       const nativePath = await this.handler.getNatives()


### PR DESCRIPTION
Some changes to increase stability and lib performance

P.S. in [added checksum awaiting in downloadToDirectory() func](https://github.com/Pierce01/MinecraftLauncher-core/commit/4d59cb577481fcb2d8fb395c760bac1c238848df) checksum used to return promise, so the check has never returned true